### PR TITLE
feat: Add endpoints to retrieve specific and all user files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ package-lock.json
 .DS_Store
 *.swp
 *~
+
+files_manager/
+image.png
+image_upload.py

--- a/routes/index.js
+++ b/routes/index.js
@@ -12,5 +12,7 @@ route.get('/connect', AuthController.getConnect);
 route.get('/disconnect', AuthController.getDisconnect);
 route.get('/users/me', AuthController.getMe);
 route.post('/files', FilesController.postUpload);
+route.get('/files', FilesController.getIndex);
+route.get('/files/:id', FilesController.getShow);
 
 export default route;


### PR DESCRIPTION
Added GET /files/:id endpoint in routes/index.js to retrieve a specific file document based on ID.

Added GET /files endpoint in routes/index.js to retrieve all user file documents with pagination.

Implemented FilesController.getShow to handle file retrieval by ID.

Implemented FilesController.getIndex to handle retrieval of all user file documents for a specific parentId with pagination.

Added authentication checks to both endpoints to ensure valid user tokens.

Handled various error cases, including unauthorized access and file not found scenarios.